### PR TITLE
SysUI/LLS: Slide panel out when collapse called

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -2811,4 +2811,8 @@ public class NotificationPanelView extends PanelView implements
         List<ActivityManager.RunningTaskInfo> tasks = am.getRunningTasks(1);
         return !tasks.isEmpty() && pkgName.equals(tasks.get(0).topActivity.getPackageName());
     }
+
+    public void slideLockScreenOut() {
+        mSwipeCallback.onChildDismissed(this);
+    }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/LiveLockScreenController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/LiveLockScreenController.java
@@ -163,7 +163,7 @@ public class LiveLockScreenController {
                 mHandler.post(new Runnable() {
                     @Override
                     public void run() {
-                        mBar.focusKeyguardExternalView();
+                        mPanelView.slideLockScreenOut();
                     }
                 });
             }


### PR DESCRIPTION
The actions performed when collapseNotificationPanel is called
needed to be updated with the introduction of the new sliding
notification panel UX.

Change-Id: I5914242cf9586b49f90ee51db5e64ef2a0b27397
TICKET: CYNGNOS-2354